### PR TITLE
Update Python versions used in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
   - "3.6-dev"
   - "3.7-dev"
   - "nightly"
-  - "pypy"
+  - "pypy2"
   - "pypy3"
-  - "pypy-5.3.1"
+  - "pypy2.7-5.9.0"
 
 cache:
     directories:


### PR DESCRIPTION
pypy 5.3.1 is no longer provided by Travis - 5.9.0 is the oldest pypy2 version available.
https://docs.travis-ci.com/user/languages/python/#python-versions